### PR TITLE
Add tail and git version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOCKER_IMAGE := rdxsl/docker-logs-agent
 
 DOCKER_REGISTRY := ${DOCKER_REGISTRY}
 
-APP_VERSION ?= $(shell cat version/version.go | grep 'Version = ' | cut -d ' ' -f 4 | sed 's/"//g')
+APP_VERSION ?= $(shell git describe --long)
 
 all: clean test build
 
@@ -32,10 +32,10 @@ testwithrace:
 
 
 bin/darwin/amd64/$(BINARY): $(GOFILES)
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -a -installsuffix cgo -ldflags="-s $(VERSION_UPDATE_FLAG)" -o "$@" main.go
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=darwin go build -a -installsuffix cgo  -ldflags="-w -s" -ldflags="-X main.Version=$(APP_VERSION)" -o "$@" main.go
 
 bin/linux/amd64/$(BINARY): $(GOFILES)
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -a -installsuffix cgo -ldflags="-s $(VERSION_UPDATE_FLAG)" -o "$@" main.go
+	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -a -installsuffix cgo  -ldflags="-w -s" -ldflags="-X main.Version=$(APP_VERSION)" -o "$@" main.go
 
 docker_image: build bin/linux/amd64/$(BINARY)
 	ls -al bin/linux/amd64/$(EXECUTABLE)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Web wrapper to access docker logs via unix socket `/var/run/docker.sock`. Only use this in a secure network environment.
 
+## Versioning
+run the following command to add new version
+```
+git tag 1.1.X -m "add some message"
+```
+
 ## Testing
 ```
 make docker_image

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ make docker_image
 
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock  -p 7001:7001 rdxsl/docker-logs-agent:$VERSION
 
-curl -X GET "http://localhost:7001/v1/containers/$containerID/logs"
+curl -X GET "http://localhost:7001/v1/containers/$containerID/logs/$tail" #$tail is optional
+
 ```
 
 ## Deploy

--- a/controllers/container.go
+++ b/controllers/container.go
@@ -14,13 +14,15 @@ type ContainerController struct {
 // @Title Get
 // @Description find object by objectid
 // @Param	containerId		path 	string	true		"the containerId you want to get"
+// @Param	tail		path 	string	false		"number of lines you want to get"
 // @Success 200 {container} models.Container
 // @Failure 403 :containerID is empty
-// @router /:containerId/logs [get]
+// @router /:containerId/logs/:tail [get]
 func (o *ContainerController) Get() {
 	containerId := o.Ctx.Input.Param(":containerId")
+	tail := o.Ctx.Input.Param(":tail")
 	if containerId != "" {
-		ob, err := models.GetLog(containerId)
+		ob, err := models.GetLog(containerId, tail)
 		if err != nil {
 			o.Data["json"] = err.Error()
 		} else {

--- a/controllers/default.go
+++ b/controllers/default.go
@@ -1,0 +1,18 @@
+package controllers
+
+import (
+	"github.com/astaxie/beego"
+)
+
+var Version string
+
+type MainController struct {
+	beego.Controller
+}
+
+func (this *MainController) Get() {
+	VersionJson := map[string]string{"docker-logs-agent": Version}
+	VersionJson["docker-api"] = beego.AppConfig.String("docker_api_version")
+	this.Data["json"] = VersionJson
+	this.ServeJSON()
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"github.com/rdxsl/docker-logs-agent/controllers"
 	_ "github.com/rdxsl/docker-logs-agent/routers"
 
 	"github.com/astaxie/beego"
 )
+
+var Version = "version notset"
 
 func main() {
 	if beego.BConfig.RunMode == "dev" {
 		beego.BConfig.WebConfig.DirectoryIndex = true
 		beego.BConfig.WebConfig.StaticDir["/swagger"] = "swagger"
 	}
+	controllers.Version = Version
 	beego.Run()
 }

--- a/models/container.go
+++ b/models/container.go
@@ -22,18 +22,21 @@ func init() {
 	Containers = make(map[string]*Container)
 }
 
-func GetLog(ContainerId string) (string, error) {
-	return dockerContainerLogs(ContainerId)
+func GetLog(ContainerId string, tail string) (string, error) {
+	return dockerContainerLogs(ContainerId, tail)
 }
 
-func dockerContainerLogs(ContainerId string) (string, error) {
+func dockerContainerLogs(ContainerId string, tail string) (string, error) {
 	ctx := context.Background()
 	cli, err := client.NewClientWithOpts(client.WithVersion(beego.AppConfig.String("docker_api_version")))
 	if err != nil {
 		return "can't connect to docker api", err
 	}
 
-	options := types.ContainerLogsOptions{ShowStdout: true}
+	options := types.ContainerLogsOptions{
+		ShowStdout: true,
+		Tail:       tail,
+	}
 	// Replace this ID with a container that really exists
 	out, err := cli.ContainerLogs(ctx, ContainerId, options)
 	if err != nil {

--- a/routers/commentsRouter__________controllers.go
+++ b/routers/commentsRouter__________controllers.go
@@ -10,7 +10,7 @@ func init() {
     beego.GlobalControllerRouter["github.com/rdxsl/docker-logs-agent/controllers:ContainerController"] = append(beego.GlobalControllerRouter["github.com/rdxsl/docker-logs-agent/controllers:ContainerController"],
         beego.ControllerComments{
             Method: "Get",
-            Router: `/:containerId/logs/:tail`,
+            Router: `/:containerId/logs`,
             AllowHTTPMethods: []string{"get"},
             MethodParams: param.Make(),
             Filters: nil,

--- a/routers/router.go
+++ b/routers/router.go
@@ -21,4 +21,5 @@ func init() {
 		),
 	)
 	beego.AddNamespace(ns)
+	beego.Router("/", &controllers.MainController{})
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,0 @@
-package version
-
-// Version is the current version of the application.
-var Version = "0.0.5"


### PR DESCRIPTION
1. allow make to use `git describe --long` to generate VERSION  …
2. default http://:7001/will show docker-api version and app version
3. add `tail` option to the api